### PR TITLE
Update PHP versions in tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,7 +23,7 @@ jobs:
               uses: actions/checkout@v1
 
             - name: Setup PHP
-              uses: shivammathur/setup-php@v1
+              uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php }}
                   coverage: none

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
 
         strategy:
             matrix:
-                php: [8.0, 7.4, 7.3, 7.2, 7.1, 5.6]
+                php: [8.1, 8.0, 7.4, 7.3, 7.2]
 
         name: PHP${{ matrix.php }} - ubuntu-latest
 

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,6 @@
     },
     "require-dev": {
         "orchestra/testbench": "^4.0|^5.0|^6.0",
-        "phpunit/phpunit": "^9.3"
+        "phpunit/phpunit": "^8.5|^9.3"
     }
 }


### PR DESCRIPTION
The package is designed for Laravel 6 upwards which requires PHP 7.2 or higher (https://laravel.com/docs/6.x#server-requirements). Therefore we don't need to test for PHP 7.1 / 5.6