### PR TITLE
Allow null sort order to be changed

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
 
         strategy:
             matrix:
-                php: [8.1, 8.0, 7.4, 7.3, 7.2]
+                php: [8.1, 8.0]
 
         name: PHP${{ matrix.php }} - ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ Sieve will also allow consumers of your API to specify sort order. You can do th
  * `sort=age:asc`
  * `sort=id:desc`
 
+By default, MySQL will sort `null` values first for ascending sorts and last for descending sorts. Depending on the context
+of the column this may not be the desired functionality. You can change this using the following URL queries:
+
+* `sort=priority:asc_nulls_last`
+* `sort=priority:desc_nulls_first`
+
+
 You can set a default sort using the `setDefaultSort` on the`Sieve` class.
 
 ```php

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     },
     "minimum-stability": "dev",
     "require": {
+        "php": "^8.0|^8.1",
         "illuminate/database": "^6.0|^7.30.4|^8.0|^9.0",
         "illuminate/http": "^6.0|^7.0|^8.0|^9.0"
     },

--- a/src/Sieve.php
+++ b/src/Sieve.php
@@ -12,6 +12,8 @@ class Sieve
 
     protected $defaultSort = null;
 
+    protected $sortable = [];
+
     public function __construct(Request $request)
     {
         $this->request = $request;
@@ -37,7 +39,7 @@ class Sieve
     public function apply($queryBuilder)
     {
         foreach ($this->getFilters() as $sieveFilter) {
-            /** @var Filter */
+            /** @var ModifiesQueries */
             $filter = $sieveFilter['filter'];
             $property = $sieveFilter['property'];
 
@@ -76,6 +78,16 @@ class Sieve
 
             if ($this->getSort() == "$property:asc") {
                 $queryBuilder->orderBy($column, "asc");
+            }
+
+            if ($this->getSort() == "$property:asc_nulls_last") {
+                $queryBuilder->orderByRaw("ISNULL(\"$column\") asc")
+                    ->orderBy($column, 'asc');
+            }
+
+            if ($this->getSort() == "$property:desc_nulls_first") {
+                $queryBuilder->orderByRaw("ISNULL(\"$column\") desc")
+                    ->orderBy($column, 'desc');
             }
         }
 

--- a/tests/SieveTest.php
+++ b/tests/SieveTest.php
@@ -77,6 +77,54 @@ class SieveTest extends TestCase
     /**
      * @test
      */
+    public function applies_sieve_sorts_to_a_query_builder_asc_nulls_last()
+    {
+        $request = Request::create('/', 'GET', [
+            'sort' => 'name:asc_nulls_last',
+        ]);
+
+        $seive = new Sieve($request);
+        $seive->addFilter('name', new StringFilter);
+
+        /** @var Builder */
+        $builder = $this->app->make(Builder::class);
+        $builder->from('pets');
+
+        $seive->apply($builder);
+
+        $this->assertEquals(
+            'select * from "pets" order by ISNULL("name") asc, "name" asc',
+            $builder->toSql()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function applies_sieve_sorts_to_a_query_builder_desc_nulls_first()
+    {
+        $request = Request::create('/', 'GET', [
+            'sort' => 'name:desc_nulls_first',
+        ]);
+
+        $seive = new Sieve($request);
+        $seive->addFilter('name', new StringFilter);
+
+        /** @var Builder */
+        $builder = $this->app->make(Builder::class);
+        $builder->from('pets');
+
+        $seive->apply($builder);
+
+        $this->assertEquals(
+            'select * from "pets" order by ISNULL("name") desc, "name" desc',
+            $builder->toSql()
+        );
+    }
+
+    /**
+     * @test
+     */
     public function ignores_undefined_sort()
     {
         $request = Request::create('/', 'GET', [


### PR DESCRIPTION
I've based the queries on this article https://gregrs-uk.github.io/2011-02-02/mysql-order-by-with-nulls-first-or-last/

In load balancers we have a priority column which is null for no priority and a number to set a priority with 1 being highest. This change will allow us to sort by ?sort=priority:asc_nulls_last which is correct in the context of a priority rather than the current ordering of nulls first, then numeric from 1, 2 onwards.